### PR TITLE
Avoid "uninitialized value in split" warnings in SMTP transport

### DIFF
--- a/lib/Email/Sender/Transport/SMTP.pm
+++ b/lib/Email/Sender/Transport/SMTP.pm
@@ -74,6 +74,7 @@ has localport => (is => 'ro', isa => 'Int');
 # later. -- rjbs, 2008-12-05
 sub _quoteaddr {
   my $addr       = shift;
+  $addr = '' unless defined $addr;
   my @localparts = split /\@/, $addr;
   my $domain     = pop @localparts;
   my $localpart  = join q{@}, @localparts;

--- a/t/smtp-via-mock.t
+++ b/t/smtp-via-mock.t
@@ -30,7 +30,7 @@ BEGIN {
   $mock_smtp->{failaddr}{'permfail@example.net'} = [ 519 => 'Permanent STHU' ];
 }
 
-plan tests => 94;
+plan tests => 98;
 
 use Email::Sender::Transport::SMTP;
 use Email::Sender::Transport::SMTP::Persistent;
@@ -346,4 +346,23 @@ for my $class (qw(
       },
     );
   }
+
+  # Warning on missing from address?  2010-10-22 mjd@icgroup.com
+  {
+    local $test = 'simple okay with omitted from addr';
+    my @warnings;
+    local $SIG{__WARN__} = sub { push @warnings, @_ };
+    test_smtp(
+      {
+        from => undef,
+        to   => 'okay@example.com',
+      },
+      sub {
+          is(@warnings, 0, 'No warnings for omitted from addr');
+          note $_ for @warnings;
+        },
+      undef,
+    );
+  }
+
 }


### PR DESCRIPTION
Some ICG cron jobs generate frequent spurious warnings because of this.   For example:

From:   cron/billing.icgroup.com cron@billing.icgroup.com
To:     root@billing.icgroup.com
Subject:    process_chilltills -p --verbose
Date:   10/22/2010 08:00:15 AM

Command: /icg/bin/process_chilltills -p --verbose
Time   : 14.4109s
Status : {{{"core": 0, "exit": 0, "signal": 0, "status": 0}}}

Output :

Use of uninitialized value in split at /usr/pkg/lib/perl5/site_perl/5.8.0/Email/Sender/Transport/SMTP.pm line 40.
Use of uninitialized value in split at /usr/pkg/lib/perl5/site_perl/5.8.0/Email/Sender/Transport/SMTP.pm line 40.
Use of uninitialized value in split at /usr/pkg/lib/perl5/site_perl/5.8.0/Email/Sender/Transport/SMTP.pm line 40.

The warning is generated when the caller of Transport::SMTP->send_mail leaves the envelope sender undefined.  The rest of the code treats this as an empty string, which is valid, but also produces these warnings.  
