### PR TITLE
Any::Moose instead of Moose

### DIFF
--- a/lib/Email/Sender.pm
+++ b/lib/Email/Sender.pm
@@ -1,5 +1,5 @@
 package Email::Sender;
-use Moose::Role;
+use Any::Moose 'Role';
 # ABSTRACT: a library for sending email
 
 requires 'send';
@@ -53,5 +53,5 @@ L<Email::Sender::Failure> on failure.
 
 =cut
 
-no Moose::Role;
+no Any::Moose 'Role';
 1;

--- a/lib/Email/Sender/Failure.pm
+++ b/lib/Email/Sender/Failure.pm
@@ -1,5 +1,5 @@
 package Email::Sender::Failure;
-use Moose;
+use Any::Moose;
 extends 'Throwable::Error';
 # ABSTRACT: a report of failure from an email sending transport
 
@@ -68,5 +68,5 @@ sub BUILD {
 =cut
 
 __PACKAGE__->meta->make_immutable(inline_constructor => 0);
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Email/Sender/Failure/Multi.pm
+++ b/lib/Email/Sender/Failure/Multi.pm
@@ -1,5 +1,5 @@
 package Email::Sender::Failure::Multi;
-use Moose;
+use Any::Moose;
 extends 'Email::Sender::Failure';
 # ABSTRACT: an aggregate of multiple failures
 
@@ -50,5 +50,5 @@ sub isa {
 }
 
 __PACKAGE__->meta->make_immutable(inline_constructor => 0);
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Email/Sender/Failure/Permanent.pm
+++ b/lib/Email/Sender/Failure/Permanent.pm
@@ -1,8 +1,8 @@
 package Email::Sender::Failure::Permanent;
-use Moose;
+use Any::Moose;
 extends 'Email::Sender::Failure';
 # ABSTRACT: a permanent delivery failure
 
 __PACKAGE__->meta->make_immutable(inline_constructor => 0);
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Email/Sender/Failure/Temporary.pm
+++ b/lib/Email/Sender/Failure/Temporary.pm
@@ -1,8 +1,8 @@
 package Email::Sender::Failure::Temporary;
-use Moose;
+use Any::Moose;
 extends 'Email::Sender::Failure';
 # ABSTRACT: a temporary delivery failure
 
 __PACKAGE__->meta->make_immutable(inline_constructor => 0);
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Email/Sender/Role/CommonSending.pm
+++ b/lib/Email/Sender/Role/CommonSending.pm
@@ -1,5 +1,5 @@
 package Email::Sender::Role::CommonSending;
-use Moose::Role;
+use Any::Moose 'Role';
 # ABSTRACT: the common sending tasks most Email::Sender classes will need
 
 use Carp;
@@ -108,5 +108,5 @@ sub success {
   my $success = Email::Sender::Success->new(@_);
 }
 
-no Moose::Role;
+no Any::Moose 'Role';
 1;

--- a/lib/Email/Sender/Role/HasMessage.pm
+++ b/lib/Email/Sender/Role/HasMessage.pm
@@ -1,5 +1,5 @@
 package Email::Sender::Role::HasMessage;
-use Moose::Role;
+use Any::Moose 'Role';
 # ABSTRACT: an object that has a message
 
 =attr message
@@ -13,5 +13,5 @@ has message => (
   required => 1,
 );
 
-no Moose::Role;
+no Any::Moose 'Role';
 1;

--- a/lib/Email/Sender/Simple.pm
+++ b/lib/Email/Sender/Simple.pm
@@ -1,5 +1,5 @@
 package Email::Sender::Simple;
-use Moose;
+use Any::Moose;
 with 'Email::Sender::Role::CommonSending';
 # ABSTRACT: the simple interface for sending mail with Sender
 
@@ -35,7 +35,7 @@ use Try::Tiny;
   sub default_transport {
     return $DEFAULT_TRANSPORT if $DEFAULT_TRANSPORT;
     my ($self) = @_;
-    
+
     if ($ENV{EMAIL_SENDER_TRANSPORT}) {
       my $transport_class = $ENV{EMAIL_SENDER_TRANSPORT};
 
@@ -43,7 +43,8 @@ use Try::Tiny;
         $transport_class = "Email::Sender::Transport::$transport_class";
       }
 
-      Class::MOP::load_class($transport_class);
+      require Class::Load;
+      Class::Load::load_class($transport_class);
 
       my %arg;
       for my $key (grep { /^EMAIL_SENDER_TRANSPORT_\w+/ } keys %ENV) {
@@ -158,5 +159,5 @@ sub _get_to_from {
   return ($to, $from);
 }
 
-no Moose;
+no Any::Moose;
 "220 OK";

--- a/lib/Email/Sender/Success.pm
+++ b/lib/Email/Sender/Success.pm
@@ -1,5 +1,5 @@
 package Email::Sender::Success;
-use Moose;
+use Any::Moose;
 # ABSTRACT: the result of successfully sending mail
 
 =head1 DESCRIPTION
@@ -10,5 +10,5 @@ successfully sent.  Unless extended, it has no properties of its own.
 =cut
 
 __PACKAGE__->meta->make_immutable;
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Email/Sender/Success/Partial.pm
+++ b/lib/Email/Sender/Success/Partial.pm
@@ -1,5 +1,5 @@
 package Email::Sender::Success::Partial;
-use Moose;
+use Any::Moose;
 extends 'Email::Sender::Success';
 # ABSTRACT: a report of partial success when delivering
 
@@ -20,5 +20,5 @@ has failure => (
 );
 
 __PACKAGE__->meta->make_immutable;
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Email/Sender/Transport.pm
+++ b/lib/Email/Sender/Transport.pm
@@ -1,5 +1,5 @@
 package Email::Sender::Transport;
-use Moose::Role;
+use Any::Moose 'Role';
 # ABSTRACT: a role for email transports
 
 =head1 DESCRIPTION
@@ -36,5 +36,5 @@ sub is_simple {
 
 sub allow_partial_success { 0 }
 
-no Moose::Role;
+no Any::Moose 'Role';
 1;

--- a/lib/Email/Sender/Transport/DevNull.pm
+++ b/lib/Email/Sender/Transport/DevNull.pm
@@ -1,5 +1,5 @@
 package Email::Sender::Transport::DevNull;
-use Moose;
+use Any::Moose;
 with 'Email::Sender::Transport';
 # ABSTRACT: happily throw away your mail
 
@@ -13,5 +13,5 @@ DevNull transport will be silently discarded.
 sub send_email { return $_[0]->success }
 
 __PACKAGE__->meta->make_immutable;
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Email/Sender/Transport/Failable.pm
+++ b/lib/Email/Sender/Transport/Failable.pm
@@ -1,5 +1,5 @@
 package Email::Sender::Transport::Failable;
-use Moose;
+use Any::Moose;
 extends 'Email::Sender::Transport::Wrapper';
 # ABSTRACT: a wrapper to makes things fail predictably
 
@@ -46,5 +46,5 @@ around send_email => sub {
 };
 
 __PACKAGE__->meta->make_immutable;
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Email/Sender/Transport/Maildir.pm
+++ b/lib/Email/Sender/Transport/Maildir.pm
@@ -1,5 +1,5 @@
 package Email::Sender::Transport::Maildir;
-use Moose;
+use Any::Moose;
 with 'Email::Sender::Transport';
 # ABSTRACT: deliver mail to a maildir on disk
 
@@ -127,5 +127,5 @@ sub _delivery_fh {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Email/Sender/Transport/Mbox.pm
+++ b/lib/Email/Sender/Transport/Mbox.pm
@@ -1,5 +1,5 @@
 package Email::Sender::Transport::Mbox;
-use Moose;
+use Any::Moose;
 with 'Email::Sender::Transport';
 # ABSTRACT: deliver mail to an mbox on disk
 
@@ -109,5 +109,5 @@ sub _unlock {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Email/Sender/Transport/Print.pm
+++ b/lib/Email/Sender/Transport/Print.pm
@@ -1,5 +1,5 @@
 package Email::Sender::Transport::Print;
-use Moose;
+use Any::Moose;
 with 'Email::Sender::Transport';
 # ABSTRACT: print email to a filehandle (like stdout)
 
@@ -37,5 +37,5 @@ sub send_email {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Email/Sender/Transport/SMTP.pm
+++ b/lib/Email/Sender/Transport/SMTP.pm
@@ -1,5 +1,5 @@
 package Email::Sender::Transport::SMTP;
-use Moose 0.90;
+use Any::Moose;
 # ABSTRACT: send email over SMTP
 
 use Email::Sender::Failure::Multi;
@@ -207,12 +207,12 @@ sub send_email {
 
 my %SUCCESS_CLASS;
 BEGIN {
-  $SUCCESS_CLASS{FULL} = Moose::Meta::Class->create_anon_class(
+  $SUCCESS_CLASS{FULL} = any_moose('::Meta::Class')->create_anon_class(
     superclasses => [ 'Email::Sender::Success' ],
     roles        => [ 'Email::Sender::Role::HasMessage' ],
     cache        => 1,
   );
-  $SUCCESS_CLASS{PARTIAL} = Moose::Meta::Class->create_anon_class(
+  $SUCCESS_CLASS{PARTIAL} = any_moose('::Meta::Class')->create_anon_class(
     superclasses => [ 'Email::Sender::Success::Partial' ],
     roles        => [ 'Email::Sender::Role::HasMessage' ],
     cache        => 1,
@@ -242,5 +242,5 @@ documentation.
 
 with 'Email::Sender::Transport';
 __PACKAGE__->meta->make_immutable;
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Email/Sender/Transport/SMTP/Persistent.pm
+++ b/lib/Email/Sender/Transport/SMTP/Persistent.pm
@@ -1,5 +1,5 @@
 package Email::Sender::Transport::SMTP::Persistent;
-use Moose;
+use Any::Moose;
 extends 'Email::Sender::Transport::SMTP';
 # ABSTRACT: an SMTP client that stays online
 
@@ -54,5 +54,5 @@ sub disconnect {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Email/Sender/Transport/Sendmail.pm
+++ b/lib/Email/Sender/Transport/Sendmail.pm
@@ -1,5 +1,5 @@
 package Email::Sender::Transport::Sendmail;
-use Moose;
+use Any::Moose;
 with 'Email::Sender::Transport';
 # ABSTRACT: send mail via sendmail(1)
 
@@ -92,5 +92,5 @@ sub send_email {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Email/Sender/Transport/Test.pm
+++ b/lib/Email/Sender/Transport/Test.pm
@@ -1,5 +1,5 @@
 package Email::Sender::Transport::Test;
-use Moose;
+use Any::Moose;
 # ABSTRACT: deliver mail in memory for testing
 
 use Email::Sender::Failure::Multi;
@@ -119,5 +119,5 @@ sub send_email {
 
 with 'Email::Sender::Transport';
 __PACKAGE__->meta->make_immutable;
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Email/Sender/Transport/Wrapper.pm
+++ b/lib/Email/Sender/Transport/Wrapper.pm
@@ -1,5 +1,5 @@
 package Email::Sender::Transport::Wrapper;
-use Moose;
+use Any::Moose;
 with 'Email::Sender::Transport';
 # ABSTRACT: a mailer to wrap a mailer for mailing mail
 
@@ -24,5 +24,5 @@ sub send_email {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Moose;
+no Any::Moose;
 1;

--- a/t/lib/Test/Email/SMTPRig.pm
+++ b/t/lib/Test/Email/SMTPRig.pm
@@ -1,5 +1,5 @@
 package Test::Email::SMTPRig;
-use Moose;
+use Any::Moose;
 
 has 'smtp_host' => (is => 'ro', required => 1);
 has 'smtp_ssl'  => (is => 'ro', default  => 0);
@@ -66,5 +66,5 @@ has 'plan' => (
 );
 
 __PACKAGE__->meta->make_immutable;
-no Moose;
+no Any::Moose;
 1;

--- a/t/test.t
+++ b/t/test.t
@@ -69,7 +69,7 @@ is_deeply(
 
 {
   package Email::Sender::Transport::TestFail;
-  use Moose;
+  use Any::Moose;
   extends 'Email::Sender::Transport::Test';
 
   sub delivery_failure {
@@ -106,7 +106,7 @@ is_deeply(
     return;
   }
 
-  no Moose;
+  no Any::Moose;
 }
 
 my $fail_test = Email::Sender::Transport::TestFail->new;

--- a/t/util-fail.t
+++ b/t/util-fail.t
@@ -7,12 +7,12 @@ use Email::Sender::Util;
 
 {
   package FakeSMTP;
-  use Moose;
+  use Any::Moose;
 
   has code    => (is => 'rw');
   has message => (is => 'rw');
 
-  no Moose;
+  no Any::Moose;
 }
 
 sub smtp { FakeSMTP->new({ code => $_[0], message => $_[1] }); }


### PR DESCRIPTION
Inspired by your "Email hates the living" talk i figured i'd spend some time to see how hard it would be to port Email::Sender to Any::Moose and it turns out it is actually really simple. I made all changes that seemed appropiate and all the tests in t/ (aside from the smtprig one) still pass. The only hangup was that Throwable needed to be ported to Any::Moose as well for this to be of any use, so you'll get a pull request for that in a minute.

Lastly, if you don't like this, feel free to let me know and close, it was only an experiment for me that led to faster results than i expected. :)
