### PR TITLE
increase minimum versions of Moo and Throwable::Error dependenices

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -14,12 +14,12 @@ Module::Runtime  = 0
 Email::Abstract  = 3 ; XXX: really use Abstract?; 3 = \$str
 Email::Address   = 0 ; used for env-from-msg (::Simple)
 List::MoreUtils  = 0 ; minimum version unknown; uniq
-Moo              = 1.000001
+Moo              = 1.000007
 Moo::Role        = 0
 MooX::Types::MooseLike::Base = 0
 Net::SMTP        = 0 ;
 Try::Tiny        = 0 ; required by Moose, anyway
-Throwable::Error = 0.100090 ; with $obj->throw and ->throw($str)
+Throwable::Error = 0.200003 ; with $obj->throw and ->throw($str) and Moo
 
 ; SOON TO NOT BE PREREQUISIES ?
 Email::Simple       = 1.998 ; needed(?) for ->header_obj


### PR DESCRIPTION
This commit fixes the test failures that occurred here:

http://www.cpantesters.org/cpan/report/4c87f201-6d9f-1014-8d2f-b3391ede6b02

Specifically:
- Throwable::Error 0.200003 starts using Moo
- Moo 1.000004 allows 'has \@attributes'

~~You might wish to pull up the Moo req up to 1.000007 even, as the intervening releases are all bug fixes.~~
