### PR TITLE
The delete_header method is a lie

### DIFF
--- a/lib/Email/Sender/Manual/QuickStart.pm
+++ b/lib/Email/Sender/Manual/QuickStart.pm
@@ -224,7 +224,7 @@ and then send it to the To/Cc users implicitly.
 
   my $message = create_email_mime_msg;  # <- whatever you do to get the message
 
-  $message->delete_header('bcc');       # delete the Bcc header before sending
+  $message->header_set('bcc');          # delete the Bcc header before sending
   sendmail($message, { to => $rcpt' }); # send to explicit Bcc address
   sendmail($message);                   # and then send as normal
 


### PR DESCRIPTION
I can't seem to find the delete_header method anywhere. Calling header_set with only the header accomplishes the same trick.
