### PR TITLE
Changed SSL to use the SSL support in Net::SMTP > 2.37

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -9,6 +9,7 @@ copyright_holder = Ricardo Signes
 Moo                    = 1.000008 ; bugfixes related to old Mouse installs
 MooX::Types::MooseLike = 0.15     ; InstanceOf uses ->isa
 Throwable::Error = 0.200003       ; with $obj->throw and ->throw($str) and Moo
+Net::SMTP   = 2.37                ; the first (not broken) version with SSL support
 
 [Prereqs / DevelopRequires]
 Sub::Override    = 0


### PR DESCRIPTION
and added an option to set IO::Socket::SSL options, such as
SSL_verifycn_name