### PR TITLE
Decode MIME-Header before testing email validity

### DIFF
--- a/lib/Email/Sender/Simple.pm
+++ b/lib/Email/Sender/Simple.pm
@@ -23,6 +23,8 @@ use Email::Address;
 use Email::Sender::Transport;
 use Email::Sender::Util;
 use Try::Tiny;
+use Encode qw/decode/;
+
 
 {
   my $DEFAULT_TRANSPORT;
@@ -146,7 +148,7 @@ sub _get_to_from {
       map  { $_->address               }
       grep { defined                   }
       map  { Email::Address->parse($_) }
-      map  { $email->get_header($_)    }
+      map  { decode('MIME-Header', $email->get_header($_))    }
       qw(to cc);
     $to = \@to_addrs;
   }
@@ -157,7 +159,7 @@ sub _get_to_from {
       map  { $_->address               }
       grep { defined                   }
       map  { Email::Address->parse($_) }
-      map  { $email->get_header($_)    }
+      map  { decode('MIME-Header', $email->get_header($_))    }
       qw(from);
   }
 


### PR DESCRIPTION
I start having some issues and found that was this missing decode, that fix if get_header gets something like '=?UTF-8?B?cmVuYXRvLmNyb25AZ21haWwuY29t?=' and transform into the appropriate form.