### PR TITLE
just use Net::SMTP if it is new enough to support ssl

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Email-Sender
 
 {{$NEXT}}
+        - avoid Net::SMTP::SSL if Net::SMTP is capable of handling SSL itself
 
 1.300021  2015-10-15 13:53:52-04:00 America/New_York
         - when SMTP connection fails, include host and port in error

--- a/lib/Email/Sender/Transport/SMTP.pm
+++ b/lib/Email/Sender/Transport/SMTP.pm
@@ -104,11 +104,10 @@ sub _smtp_client {
   my ($self) = @_;
 
   my $class = "Net::SMTP";
-  if ($self->ssl) {
+  require Net::SMTP;
+  if ($self->ssl and not eval { Net::SMTP->can_ssl } ) {
     require Net::SMTP::SSL;
     $class = "Net::SMTP::SSL";
-  } else {
-    require Net::SMTP;
   }
 
   my $smtp = $class->new( $self->_net_smtp_args );


### PR DESCRIPTION
see #34 which is a larger change for SSL handling
see also http://stackoverflow.com/questions/28709237/installing-netsmtpssl for
the errors that arise with Net::SMTP::SSL 1.01