### PR TITLE
unified STARTTLS / SSL update using Net::SMTP only

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Email-Sender
 
 {{$NEXT}}
 
+1.300025  2016-03-19 17:11:34-04:00 America/New_York (TRIAL RELEASE)
+        - tweak how we load Net::SMTP to avoid problems when testing with a
+          Test::MockObject-mocked SMTP client
+
 1.300024  2016-03-19 14:13:16-04:00 America/New_York (TRIAL RELEASE)
         - Net::SMTP 3.07 is now required, both for SSL support and for a fix
           to datasend implementation referenced in 1.300019 changes

--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Email-Sender
 
 {{$NEXT}}
 
+1.300026  2016-03-21 13:50:22-04:00 America/New_York (TRIAL RELEASE)
+        - another tweak to Net::SMTP and Test::MockObject, thanks to Matthew
+          Horsfall
+
 1.300025  2016-03-19 17:11:34-04:00 America/New_York (TRIAL RELEASE)
         - tweak how we load Net::SMTP to avoid problems when testing with a
           Test::MockObject-mocked SMTP client

--- a/Changes
+++ b/Changes
@@ -2,6 +2,12 @@ Revision history for Email-Sender
 
 {{$NEXT}}
 
+1.300023  2016-03-19 14:06:51-04:00 America/New_York (TRIAL RELEASE)
+        - Email::Sender::Transport::SMTP now uses Net::SMTP for SSL
+          connections, and for a STARTTLS implementation
+        - Net::SMTP 3.07 is now required, both for SSL support and for a fix to
+          datasend implementation referenced in 1.300019 changes
+
 1.300021  2015-10-15 13:53:52-04:00 America/New_York
         - when SMTP connection fails, include host and port in error
 

--- a/Changes
+++ b/Changes
@@ -1,12 +1,12 @@
 Revision history for Email-Sender
 
 {{$NEXT}}
+        - Net::SMTP 3.07 is now required, both for SSL support and for a fix
+          to datasend implementation referenced in 1.300019 changes
 
 1.300023  2016-03-19 14:06:51-04:00 America/New_York (TRIAL RELEASE)
         - Email::Sender::Transport::SMTP now uses Net::SMTP for SSL
           connections, and for a STARTTLS implementation
-        - Net::SMTP 3.07 is now required, both for SSL support and for a fix to
-          datasend implementation referenced in 1.300019 changes
 
 1.300021  2015-10-15 13:53:52-04:00 America/New_York
         - when SMTP connection fails, include host and port in error

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Email-Sender
 
 {{$NEXT}}
+
+1.300024  2016-03-19 14:13:16-04:00 America/New_York (TRIAL RELEASE)
         - Net::SMTP 3.07 is now required, both for SSL support and for a fix
           to datasend implementation referenced in 1.300019 changes
 

--- a/dist.ini
+++ b/dist.ini
@@ -10,6 +10,8 @@ Moo                    = 2.000000 ; do not apply fatal warnings to us!
 MooX::Types::MooseLike = 0.15     ; InstanceOf uses ->isa
 Throwable::Error = 0.200003       ; with $obj->throw and ->throw($str) and Moo
 
+Net::SMTP = 3.07 ; SSL support, fixed datasend
+
 [Prereqs / DevelopRequires]
 Sub::Override    = 0
 Test::MockObject = 0

--- a/lib/Email/Sender/Transport/SMTP.pm
+++ b/lib/Email/Sender/Transport/SMTP.pm
@@ -8,7 +8,7 @@ use Email::Sender::Success::Partial;
 use Email::Sender::Role::HasMessage ();
 use Email::Sender::Util;
 use MooX::Types::MooseLike::Base qw(Bool Int Str HashRef);
-use Net::SMTP 3.03;
+use Net::SMTP 3.07; # SSL support, fixed datasend
 
 use utf8 (); # See below. -- rjbs, 2015-05-14
 

--- a/lib/Email/Sender/Transport/SMTP.pm
+++ b/lib/Email/Sender/Transport/SMTP.pm
@@ -8,7 +8,7 @@ use Email::Sender::Success::Partial;
 use Email::Sender::Role::HasMessage ();
 use Email::Sender::Util;
 use MooX::Types::MooseLike::Base qw(Bool Int Str HashRef);
-use Net::SMTP 3.07; # SSL support, fixed datasend
+use Net::SMTP;
 
 use utf8 (); # See below. -- rjbs, 2015-05-14
 

--- a/lib/Email/Sender/Transport/SMTP.pm
+++ b/lib/Email/Sender/Transport/SMTP.pm
@@ -8,7 +8,7 @@ use Email::Sender::Success::Partial;
 use Email::Sender::Role::HasMessage ();
 use Email::Sender::Util;
 use MooX::Types::MooseLike::Base qw(Bool Int Str HashRef);
-use Net::SMTP;
+use Net::SMTP 3.07; # SSL support, fixed datasend
 
 use utf8 (); # See below. -- rjbs, 2015-05-14
 

--- a/t/smtp-via-mock.t
+++ b/t/smtp-via-mock.t
@@ -21,6 +21,8 @@ BEGIN {
   $mock_smtp->fake_new('Net::SMTP');
   Test::Email::Sender::Util->perform_stock_mockery($mock_smtp);
 
+  eval '$Net::SMTP::VERSION = "3.07"';
+
   $mock_smtp->{pass}{username} = 'password';
 
   $mock_smtp->{failaddr}{'tempfail@example.com'} = [ 401 => 'Temporary FOAD' ];


### PR DESCRIPTION
This combines and reworks updates from @markwellis, @fayland, and @wesQ3, along with my own work.

It eliminates Net::SMTP::SSL, but does not using Net::SMTPS.  It uses the SSL and STARTTLS support built into Net::SMTP.

I have not yet put this to the test, but I believe it is correct.  I will test it in the next few days.  In the meantime, I would love further feedback, as this is the way I'd like to move forward.