### PR TITLE
to and from extraction is compatible with encoded headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: perl
+sudo: false
+
+perl:
+  - "5.22"
+  - "5.20"
+  - "5.18"
+  - "5.16"
+  - "5.14"
+
+cache:
+  directories:
+    - $HOME/perl5/perlbrew/perls/$TRAVIS_PERL_VERSION/lib/site_perl/
+    - $HOME/perl5/perlbrew/perls/$TRAVIS_PERL_VERSION/bin/
+
+install:
+  - echo $TRAVIS_PERL_VERSION
+  - env | grep PERL
+  - cpanm --notest -v Dist::Zilla
+  - dzil authordeps | cpanm --quiet --notest
+  - dzil listdeps | cpanm
+
+script:
+  - dzil test --extended -j 4

--- a/dist.ini
+++ b/dist.ini
@@ -6,6 +6,7 @@ copyright_holder = Ricardo Signes
 [@RJBS]
 
 [Prereqs]
+Encode                 = 0 ; for MIME-Header decoding
 Moo                    = 2.000000 ; do not apply fatal warnings to us!
 MooX::Types::MooseLike = 0.15     ; InstanceOf uses ->isa
 Throwable::Error = 0.200003       ; with $obj->throw and ->throw($str) and Moo

--- a/lib/Email/Sender/Simple.pm
+++ b/lib/Email/Sender/Simple.pm
@@ -22,6 +22,9 @@ use Sub::Exporter -setup => {
 use Email::Address;
 use Email::Sender::Transport;
 use Email::Sender::Util;
+
+use Encode qw//;
+
 use Try::Tiny;
 
 {
@@ -145,7 +148,7 @@ sub _get_to_from {
     my @to_addrs =
       map  { $_->address               }
       grep { defined                   }
-      map  { Email::Address->parse($_) }
+      map  { Email::Address->parse( Encode::decode('MIME-Header', $_ ) ) }
       map  { $email->get_header($_)    }
       qw(to cc);
     $to = \@to_addrs;
@@ -156,7 +159,7 @@ sub _get_to_from {
     ($from) =
       map  { $_->address               }
       grep { defined                   }
-      map  { Email::Address->parse($_) }
+      map  { Email::Address->parse( Encode::decode('MIME-Header', $_ ) ) }
       map  { $email->get_header($_)    }
       qw(from);
   }

--- a/t/auto-to.t
+++ b/t/auto-to.t
@@ -1,0 +1,64 @@
+#!perl -w
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+
+use Email::Sender::Simple;
+use Email::Sender::Transport::Test;
+
+my $transport = Email::Sender::Transport::Test->new();
+
+{
+    my $message = <<'END_MESSAGE';
+From: sender@test.example.com
+To: =?UTF-8?Q?=22J=C3=A9r=C3=B4me_=C3=89t=C3=A9v=C3=A9=22_=3Crecipient=40nowh?=
+ =?UTF-8?Q?ere=2Eexample=2Enet=3E?=
+Subject: this message is going nowhere fast
+
+Dear Recipient,
+
+  You will never receive this.
+
+-- 
+sender
+END_MESSAGE
+
+    Email::Sender::Simple->send(
+        $message,
+        { transport => $transport }
+    );
+    my @deliveries = $transport->deliveries;
+    is_deeply(
+        $deliveries[0]{successes},
+        [ qw(recipient@nowhere.example.net)],
+        "first message delivered to 'recipient'",
+    );
+}
+
+{
+    my $message = <<'END_MESSAGE';
+From: sender@test.example.com
+Cc: "Another Recipient" <anotherrecipient@nowhere.example.net>
+Subject: this message is going nowhere fast
+
+Dear Recipient,
+
+  You will never receive this.
+
+-- 
+sender
+END_MESSAGE
+
+    Email::Sender::Simple->send(
+        $message,
+        { transport => $transport }
+    );
+    my @deliveries = $transport->deliveries;
+    is_deeply(
+        $deliveries[1]{successes},
+        [ qw(anotherrecipient@nowhere.example.net)],
+        "first message delivered to 'recipient'",
+    );
+}
+


### PR DESCRIPTION
Hi,

This allows users (me for instance :) )  to use MIME-Q or MIME-B encoded headers in their 'To', 'Cc', and 'From' headers and still have the automated 'to' and 'from' extraction work.

Encode::decode('MIME-Header') is idempotent and will not mess with unencoded headers as demonstrated by the test.

As a bonus, this adds a .travis.yml to allow for quick testing across several versions of perl:
https://travis-ci.org/jeteve/Email-Sender