### PR TITLE
Permit IPv6 addresses in SMTP transport

### DIFF
--- a/lib/Email/Sender/Transport/SMTP.pm
+++ b/lib/Email/Sender/Transport/SMTP.pm
@@ -27,7 +27,9 @@ The following attributes may be passed to the constructor:
 
 =over 4
 
-=item C<host>: the name of the host to connect to; defaults to C<localhost>
+=item C<host>: the DNS name, IPv4 or IPv6 address of the host to connect to;
+ defaults to C<localhost>. Do not include a port number. Use the C<port>
+ option instead.
 
 =item C<ssl>: if 'starttls', use STARTTLS; if 'ssl' (or 1), connect securely;
 otherwise, no security
@@ -45,8 +47,10 @@ IO::Socket::SSL
 
 sub BUILD {
   my ($self) = @_;
-  Carp::croak("do not pass port number to SMTP transport in host, use port parameter")
-    if $self->host =~ /:/;
+  Carp::croak("Do not pass port number to SMTP transport in host, use port parameter")
+    if $self->host =~ /^\d+\.\d+\.\d+\.\d+:/			# IPv4 address
+    or $self->host =~ /^\[[\w:]{3,}\]:/					# IPv6 address
+    or $self->host =~ /^[\w\.]{3,}:/;					# DNS name
 }
 
 has host => (is => 'ro', isa => Str, default => sub { 'localhost' });


### PR DESCRIPTION
IPv6 usage is becoming more prevalent now. My VPSs from various providers all have IPv6 addresses by default and are routing traffic over IPv6 by default. I'd like to be able to specify an IPv6 address as the SMTP host. To do this, the routine that detects the usage of a port in the hostname needs to be a little cleverer, as IPv6 addresses include the colon as a group separator. 

 - Seperate regexes for DNS, IPv4 and IPv6 in the port in host detection routine
 - Add tests for the port in host detection routine
 - Change host parameter documentation to describe supported address types

Thanks!