### PR TITLE
WIP: fix class rewriting to match documentation

### DIFF
--- a/lib/Email/Sender/Util.pm
+++ b/lib/Email/Sender/Util.pm
@@ -80,12 +80,19 @@ will be removed.
 
 =cut
 
+sub _rewrite_class {
+  my $transport_class = $_[1];
+  if ($transport_class !~ s/^=// and $transport_class !~ m{:}) {
+    $transport_class = "Email::Sender::Transport::$transport_class";
+  }
+
+  return $transport_class;
+}
+
 sub easy_transport {
   my ($self, $transport_class, $arg) = @_;
 
-  if ($transport_class =~ s/^=// or $transport_class !~ tr/://) {
-    $transport_class = "Email::Sender::Transport::$transport_class";
-  }
+  $transport_class = $self->_rewrite_class($transport_class);
 
   require_module($transport_class);
   return $transport_class->new($arg);

--- a/t/util-easy.t
+++ b/t/util-easy.t
@@ -1,0 +1,32 @@
+#!perl
+use strict;
+use warnings;
+use Test::More;
+
+use Email::Sender::Util;
+
+my $BASE = 'Email::Sender::Transport::';
+sub with_base { "$BASE" . $_[0] }
+
+my @rewrite = qw(  SMTP );
+my @untouch = qw( =SMTP SMTP::Persistent =SMTP::Persistent );
+
+for my $class (@rewrite) {
+  is(
+    Email::Sender::Util->_rewrite_class($class),
+    with_base($class),
+    "we do rewrite easy-transport class $class",
+  );
+}
+
+for my $class (@untouch) {
+  (my $no_eq = $class) =~ s/^=//;
+
+  is(
+    Email::Sender::Util->_rewrite_class($class),
+    $no_eq,
+    "we do NOT rewrite easy-transport class $class",
+  );
+}
+
+done_testing;


### PR DESCRIPTION
The previous logic was "rewrite if you remove a = or if there is no colon."

The documentation is correct: `=` is universal rjbs-ware for "Do not rewrite class name from stub" and the `or no colon` provision was very old.

The original behavior skipped rewriting `SMTP::Persistent` but the `=` sign meant nothing.

The later version rewrote things with a leading `=` but only to remove the `=`.  I don't think we can just drop the "colon means no-rewrite," sadly.  It's been working 2013.