### PR TITLE
Remove useless version check

### DIFF
--- a/lib/Email/Sender/Transport/SMTP.pm
+++ b/lib/Email/Sender/Transport/SMTP.pm
@@ -255,16 +255,6 @@ sub send_email {
   while (length $msg_string) {
     my $next_hunk = substr $msg_string, 0, $hunk_size, '';
 
-    # For the need to downgrade, see
-    #   https://rt.cpan.org/Ticket/Display.html?id=104433
-    #
-    # The ||0 is there because when we've mocked Net::SMTP, there is no
-    # version.  We can't get the ->VERSION call to hit the mock, because we get
-    # the mock from ->new.  We don't want to create a new SMTP just to get the
-    # version, and we can't rely on $smtp being a Net::SMTP object.
-    # -- rjbs, 2015-08-10
-    utf8::downgrade($next_hunk) if (Net::SMTP->VERSION || 0) < 3.07;
-
     $smtp->datasend($next_hunk) or $FAULT->("error at during DATA");
   }
 


### PR DESCRIPTION
Net::SMTP 3.07 is a requirement, hence remove code that checks for
Net::SMTP version < 3.07. This code may also caused a warning about
non-numeric $Net::SMTP::VERSION:

> Argument "3.08_01" isn't numeric in numeric lt (<) at
> /where/ever/perl5/Email/Sender/Transport/SMTP.pm line 266.

This is somehow a double of issue #46.