### PR TITLE
Do not depend on insecure module Email::Address

### DIFF
--- a/lib/Email/Sender/Manual/QuickStart.pm
+++ b/lib/Email/Sender/Manual/QuickStart.pm
@@ -48,7 +48,7 @@ This is exactly the same as saying:
 
 We didn't have to tell Email::Sender::Simple where to send the message.  If you
 don't specify recipients, it will use all the email addresses it can find in
-the F<To> and F<Cc> headers by default.  It will use L<Email::Address> to parse
+the F<To> and F<Cc> headers by default.  It will use L<Email::Address::XS> to parse
 those fields.  Similarly, if no sender is specified, it will use the first
 address found in the F<From> header.
 

--- a/lib/Email/Sender/Simple.pm
+++ b/lib/Email/Sender/Simple.pm
@@ -19,7 +19,7 @@ use Sub::Exporter -setup => {
   },
 };
 
-use Email::Address;
+use Email::Address::XS;
 use Email::Sender::Transport;
 use Email::Sender::Util;
 use Try::Tiny;
@@ -144,8 +144,7 @@ sub _get_to_from {
   unless (@$to) {
     my @to_addrs =
       map  { $_->address               }
-      grep { defined                   }
-      map  { Email::Address->parse($_) }
+      map  { Email::Address::XS->parse($_) }
       map  { $email->get_header($_)    }
       qw(to cc);
     $to = \@to_addrs;
@@ -155,8 +154,7 @@ sub _get_to_from {
   unless (defined $from) {
     ($from) =
       map  { $_->address               }
-      grep { defined                   }
-      map  { Email::Address->parse($_) }
+      map  { Email::Address::XS->parse($_) }
       map  { $email->get_header($_)    }
       qw(from);
   }

--- a/lib/Email/Sender/Util.pm
+++ b/lib/Email/Sender/Util.pm
@@ -3,7 +3,7 @@ use warnings;
 package Email::Sender::Util;
 # ABSTRACT: random stuff that makes Email::Sender go
 
-use Email::Address;
+use Email::Address::XS;
 use Email::Sender::Failure;
 use Email::Sender::Failure::Permanent;
 use Email::Sender::Failure::Temporary;
@@ -16,7 +16,7 @@ sub _recipients_from_email {
 
   my @to = List::Util::uniq(
            map { $_->address }
-           map { Email::Address->parse($_) }
+           map { Email::Address::XS->parse($_) }
            map { $email->get_header($_) }
            qw(to cc bcc));
 
@@ -27,7 +27,7 @@ sub _sender_from_email {
   my ($self, $email) = @_;
 
   my ($sender) = map { $_->address }
-                 map { Email::Address->parse($_) }
+                 map { Email::Address::XS->parse($_) }
                  scalar $email->get_header('from');
 
   return $sender;


### PR DESCRIPTION
Method Email::Address->parse is vulnerable to CVE-2015-7686 and also does
not parse list of email addresses correctly. This patch replaces it by a
new module Email::Address::XS.