### PR TITLE
Fix a typo concerning error message for ssl value

### DIFF
--- a/lib/Email/Sender/Transport/SMTP.pm
+++ b/lib/Email/Sender/Transport/SMTP.pm
@@ -63,7 +63,7 @@ has _security => (
     return 'starttls' if 'starttls' eq $ssl;
     return 'ssl' if $ssl eq 1 or $ssl eq 'ssl';
 
-    Carp::cluck(qq{true "ssl" argument to Email::Sender::Transport::SMTP should be 'ssl' or 'startls' or '1' but got '$ssl'});
+    Carp::cluck(qq{true "ssl" argument to Email::Sender::Transport::SMTP should be 'ssl' or 'starttls' or '1' but got '$ssl'});
 
     return 1;
   },


### PR DESCRIPTION
Value used should be 'ssl' or 'starttls' or '1'
Changed 'startls' to 'starttls'