### PR TITLE
Drop redundant Net::SMTP prereq mention in dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -10,8 +10,6 @@ Moo                    = 2.000000 ; do not apply fatal warnings to us!
 MooX::Types::MooseLike = 0.15     ; InstanceOf uses ->isa
 Throwable::Error = 0.200003       ; with $obj->throw and ->throw($str) and Moo
 
-Net::SMTP = 3.07 ; SSL support, fixed datasend
-
 [Prereqs / DevelopRequires]
 Sub::Override    = 0
 Test::MockObject = 0


### PR DESCRIPTION
This is a no-op as far as CPAN is concerned, so it has no urgency. Just a bit of housework, for somewhere down the line.