### PR TITLE
Close #71: Allow explicit specification of SASL mechanisms

### DIFF
--- a/lib/Email/Sender/Transport/SMTP.pm
+++ b/lib/Email/Sender/Transport/SMTP.pm
@@ -49,6 +49,11 @@ sub BUILD {
   my ($self) = @_;
   Carp::croak("do not pass port number to SMTP transport in host, use port parameter")
     if grep {; /:/ } $self->hosts;
+
+  if ($self->sasl_username) {
+    $self->_throw("sasl_username but no sasl_password")
+      unless defined $self->sasl_password;
+  }
 }
 
 sub BUILDARGS {
@@ -193,9 +198,6 @@ sub _smtp_client {
   }
 
   if ($self->sasl_username) {
-    $self->_throw("sasl_username but no sasl_password")
-      unless defined $self->sasl_password;
-
     unless ($smtp->auth($self->sasl_username, $self->sasl_password)) {
       if ($smtp->message =~ /MIME::Base64|Authen::SASL/) {
         Carp::confess("SMTP auth requires MIME::Base64 and Authen::SASL");

--- a/lib/Email/Sender/Transport/SMTP.pm
+++ b/lib/Email/Sender/Transport/SMTP.pm
@@ -66,9 +66,8 @@ sub BUILDARGS {
     $arg->{hosts} = [ delete $arg->{host} ];
   }
 
-  if (exists $arg->{sasl_authenticator}
-      and exists $arg->{sasl_username}) {
-      Carp::croak("can't pass both sasl_authenticator and sasl_username to constructor");
+  if (exists $arg->{sasl_authenticator} and exists $arg->{sasl_username}) {
+    Carp::croak("can't pass both sasl_authenticator and sasl_username to constructor");
   }
 
   return $arg;

--- a/lib/Email/Sender/Transport/SMTP.pm
+++ b/lib/Email/Sender/Transport/SMTP.pm
@@ -7,7 +7,7 @@ use Email::Sender::Failure::Multi;
 use Email::Sender::Success::Partial;
 use Email::Sender::Role::HasMessage ();
 use Email::Sender::Util;
-use MooX::Types::MooseLike::Base qw(Bool Int Str HashRef);
+use MooX::Types::MooseLike::Base qw(Bool InstanceOf Int Str HashRef);
 use Net::SMTP 3.07; # SSL support, fixed datasend
 
 use utf8 (); # See below. -- rjbs, 2015-05-14
@@ -65,6 +65,11 @@ sub BUILDARGS {
       if exists $arg->{hosts};
 
     $arg->{hosts} = [ delete $arg->{host} ];
+  }
+
+  if (exists $arg->{sasl_authenticator}) {
+      Carp::croak("can't pass both sasl_authenticator and sasl_username to constructor")
+          if exists $arg->{sasl_username};
   }
 
   return $arg;
@@ -125,12 +130,22 @@ has timeout => (is => 'ro', isa => Int, default => sub { 120 });
 
 =item C<sasl_password>: the password to use for auth; required if C<sasl_username> is provided
 
-=item C<allow_partial_success>: if true, will send data even if some recipients were rejected; defaults to false
-
 =cut
 
 has sasl_username => (is => 'ro', isa => Str);
 has sasl_password => (is => 'ro', isa => Str);
+
+=item C<sasl_authenticator>: An C<Authen::SASL> instance to use for auth; optional
+
+The C<sasl_authenticator> and C<sasl_username> attributes are mutually exclusive.
+
+=cut
+
+has sasl_authenticator => (is => 'ro', isa => InstanceOf['Authen::SASL']);
+
+=item C<allow_partial_success>: if true, will send data even if some recipients were rejected; defaults to false
+
+=cut
 
 has allow_partial_success => (is => 'ro', isa => Bool, default => sub { 0 });
 
@@ -170,6 +185,20 @@ sub _quoteaddr {
   return join q{@}, qq("$localpart"), $domain;
 }
 
+sub _maybe_auth {
+  my ($self, $smtp) = @_;
+
+  if ($self->sasl_username) {
+    return $smtp->auth($self->sasl_username, $self->sasl_password);
+  }
+
+  if ($self->sasl_authenticator) {
+    return $smtp->auth($self->sasl_authenticator);
+  }
+
+  return 1;
+}
+
 sub _smtp_client {
   my ($self) = @_;
 
@@ -197,14 +226,12 @@ sub _smtp_client {
     }
   }
 
-  if ($self->sasl_username) {
-    unless ($smtp->auth($self->sasl_username, $self->sasl_password)) {
-      if ($smtp->message =~ /MIME::Base64|Authen::SASL/) {
-        Carp::confess("SMTP auth requires MIME::Base64 and Authen::SASL");
-      }
-
-      $self->_throw('failed AUTH', $smtp);
+  unless ($self->_maybe_auth($smtp)) {
+    if ($smtp->message =~ /MIME::Base64|Authen::SASL/) {
+      Carp::confess("SMTP auth requires MIME::Base64 and Authen::SASL");
     }
+
+    $self->_throw('failed AUTH', $smtp);
   }
 
   return $smtp;

--- a/lib/Email/Sender/Transport/SMTP.pm
+++ b/lib/Email/Sender/Transport/SMTP.pm
@@ -50,9 +50,8 @@ sub BUILD {
   Carp::croak("do not pass port number to SMTP transport in host, use port parameter")
     if grep {; /:/ } $self->hosts;
 
-  if ($self->sasl_username) {
-    $self->_throw("sasl_username but no sasl_password")
-      unless defined $self->sasl_password;
+  if ($self->sasl_username and not defined $self->sasl_password) {
+    $self->_throw("sasl_username but no sasl_password");
   }
 }
 

--- a/lib/Email/Sender/Transport/SMTP.pm
+++ b/lib/Email/Sender/Transport/SMTP.pm
@@ -66,9 +66,9 @@ sub BUILDARGS {
     $arg->{hosts} = [ delete $arg->{host} ];
   }
 
-  if (exists $arg->{sasl_authenticator}) {
-      Carp::croak("can't pass both sasl_authenticator and sasl_username to constructor")
-          if exists $arg->{sasl_username};
+  if (exists $arg->{sasl_authenticator}
+      and exists $arg->{sasl_username}) {
+      Carp::croak("can't pass both sasl_authenticator and sasl_username to constructor");
   }
 
   return $arg;


### PR DESCRIPTION
The current implementation uses Authen::SASL with the default list of
mechanisms. With this minimal change, users of Email::Sender can select
the list of allowable mechanisms by passing in a fully configured
Authen::SASL instance.

This is a variant of code that I have in production myself and released as
part of an open source project to an unknown number of other installs. The
code can be found at https://github.com/ledgersmb/LedgerSMB/blob/master/old/lib/LedgerSMB/Mailer/TransportSMTP.pm and is used at https://github.com/ledgersmb/LedgerSMB/blob/970e0e8713ad85a2a144bf085048937d603bb1c3/old/lib/LedgerSMB/Mailer.pm#L213-L226 (instantiation of the Authen::SASL instance) and https://github.com/ledgersmb/LedgerSMB/blob/970e0e8713ad85a2a144bf085048937d603bb1c3/old/lib/LedgerSMB/Mailer.pm#L248 (instantiation of the transport).